### PR TITLE
[NQA-10532] Fix Sendgrid Mock subject URL parameter querying

### DIFF
--- a/src/server/handler/MailHandler.js
+++ b/src/server/handler/MailHandler.js
@@ -50,7 +50,7 @@ const mailSentTo = (mail, to) => {
     
     const matcherFn = to.startsWith('%') && to.endsWith('%')
       ? string => string.toLowerCase().includes(to.substring(1, to.length -1).toLowerCase())
-      : string => string.toLowerCase() == to.toLowerCase();
+      : string => string.toLowerCase() === to.toLowerCase();
 
     return mail
       .personalizations
@@ -62,15 +62,19 @@ const mailSentTo = (mail, to) => {
 };
 
 const mailContainSubject = (mail, subject) => {
-  
-  const actualSubject = mail.subject;
-  
-  if (subject.startsWith('%') && subject.endsWith('%')) {
-    const searchSubject = subject.substring(1, subject.length - 1);
-    return actualSubject.toLowerCase().includes(searchSubject.toLowerCase());
+
+  if (Array.isArray(mail.personalizations)) {
+
+    const matcherFn = subject.startsWith('%') && subject.endsWith('%')
+        ? string => string.toLowerCase().includes(subject.substring(1, subject.length -1).toLowerCase())
+        : string => string.toLowerCase() === subject.toLowerCase();
+
+    return mail
+        .personalizations
+        .some(subject => matcherFn(subject.subject));
   } else {
-    return actualSubject.toLowerCase() === subject.toLowerCase();
-  }  
+    return false;
+  }
 };
 
 const mailSentAfter = (mail, dateTime) => {

--- a/src/ui/mails/Mails.js
+++ b/src/ui/mails/Mails.js
@@ -77,7 +77,7 @@ class Mails extends React.Component {
     }
 
 
-    if (apiParams.toString() == this.lastQuery) return;
+    if (apiParams.toString() === this.lastQuery) return;
 
     this.lastQuery = apiParams.toString();
     fetch(`/api/mails?${this.lastQuery}`)
@@ -171,7 +171,15 @@ class Mails extends React.Component {
                   headerStyle: { textAlign: 'left' },
                   style: { 'whiteSpace': 'unset' },
                   minWidth: 200,
-                  accessor: mail => mail.subject
+                  accessor: mail => mail.personalizations,
+                  Cell: cellData => (
+                      cellData.value
+                          .filter(value => !!value.subject)
+                          .map(value => (
+                              <div key={value.subject}>
+                                <span>{value.subject}</span>
+                              </div>)
+                          ))
                 },
                 {
                   Header: 'to',


### PR DESCRIPTION
#### Purpose
This corrects two issues that are currently found in https://github.com/janjaali/sendGrid-mock/:
1. The email subject doesn't show up on the GUI at `localhost:3000`
2. The `subject` cannot be successfully queried using the URL parameters documented on the repos page.

This is due to differences between versions 2 and 3 of the SendGrid API (and example of the breaking change can be found directly above the linked heading https://docs.sendgrid.com/for-developers/sending-email/migrating-from-v2-to-v3-mail-send#requirements-and-limitations)

#### Approach
We have to edit two files in the original `sendGrid-mock` repo to accommodate this structure change between v2 and v3

v2
```
{
  'personalizations': [
    {
      'to': [{
        'email': 'to@example.com'
      }, {
        'email': 'to2@example.com'
      }]
    }
  ],
  'from': {
    'email': 'from@example.com'
  },
  'subject': 'important subject',
  'content': [
    {
      'type': 'text/plain',
      'value': 'important content',
    },
  ],
}
```
v3
```
{
  'personalizations': [
    {
      'to': [{
        'email': 'to@example.com'
      }, {
        'email': 'to2@example.com'
      }],
      'subject': 'important subject',
    }
  ],
  'from': {
    'email': 'from@example.com'
  },
  'content': [
    {
      'type': 'text/plain',
      'value': 'important content',
    },
  ],
}
```